### PR TITLE
Add check for excludes file

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -46,6 +46,10 @@ Simple enough. Just a note on `--exclude` option: any argument after the
 destination is passed onto rsync. Here, we're excluding `/home` because
 we don't want to duplicate the backup of `/home/joe`.
 
+If a file named ~/.rsyncbtrfs_excludes is found, the contents of that file
+will be included in the arguments passed to rsync as `--exclude_from=`.
+The format of the file is the normal rsync `--exclude_from` file format
+
 After the backup above, this is what `/backup` would look like:
 
     $ ls /backup/sys

--- a/Readme.md
+++ b/Readme.md
@@ -46,9 +46,9 @@ Simple enough. Just a note on `--exclude` option: any argument after the
 destination is passed onto rsync. Here, we're excluding `/home` because
 we don't want to duplicate the backup of `/home/joe`.
 
-If a file named ~/.rsyncbtrfs_excludes is found, the contents of that file
+If a file named ``~/.rsyncbtrfs_excludes` is found, the contents of that file
 will be included in the arguments passed to rsync as `--exclude_from=`.
-The format of the file is the normal rsync `--exclude_from` file format
+The format of the file is the normal rsync `--exclude_from` file format.
 
 After the backup above, this is what `/backup` would look like:
 

--- a/Readme.md
+++ b/Readme.md
@@ -46,7 +46,7 @@ Simple enough. Just a note on `--exclude` option: any argument after the
 destination is passed onto rsync. Here, we're excluding `/home` because
 we don't want to duplicate the backup of `/home/joe`.
 
-If a file named ``~/.rsyncbtrfs_excludes` is found, the contents of that file
+If a file named `~/.rsyncbtrfs_excludes` is found, the contents of that file
 will be included in the arguments passed to rsync as `--exclude_from=`.
 The format of the file is the normal rsync `--exclude_from` file format.
 

--- a/rsyncbtrfs
+++ b/rsyncbtrfs
@@ -27,6 +27,9 @@ init)
 
 backup)
 
+EXCLUDES_FILE="${HOME}/.rsyncbtrfs_excludes"
+EXCLUDE_ARG=""
+
   shift 1
 
   BIND_MOUNT=N
@@ -55,8 +58,15 @@ backup)
   TMP_MOUNT="`mktemp -d --tmpdir rsyncbtrfs-XXXXXXX`"
   NEW_SUBVOL="`date +%F-%T`"
 
+# check for ~/.rsyncbtrfs_excludes
+
+if [ -f "$EXCLUDES_FILE" ]
+then
+	EXCLUDE_ARG=" --exclude-from=$EXCLUDES_FILE "
+fi
+
   # Cleanup handlers
- 
+
   trap '
     umount "$TMP_MOUNT" >/dev/null 2>&1
     rmdir "$TMP_MOUNT"
@@ -64,7 +74,7 @@ backup)
     rm -f "$TMP_INPROG/cur"
     rmdir "$TMP_INPROG"
   ' INT QUIT TERM EXIT
-  
+
   if [ "$BIND_MOUNT" = 'Y' ]
   then
     mount --bind "$BACKUP_SRC" "$TMP_MOUNT" || exit 253
@@ -87,7 +97,7 @@ backup)
 
   # Do the backup.
 
-  rsync --delete --delete-before --delete-excluded --inplace \
+  rsync --delete --delete-before --delete-excluded --inplace $EXCLUDE_ARG \
     --no-whole-file -a $@ \
     "$RSYNC_SRC/" "$TMP_INPROG/vol" || exit 253
 


### PR DESCRIPTION
This patch checks for the existence of a file named `.rsyncbtrfs_excludes` in the user running rsyncbtrfs' home folder.  This may be too specific for general inclusion because of the way rsync resolves paths in an --exclude-from file, but it works in every case I use it in. This is no different than normal rsync in that respect though, so it may be useful to the users of your  script. As long as the user understands rsync's quirk of resolving paths in the excludes file relative to the source dir, it works great.